### PR TITLE
DM-8537: Update container networking to use non-host network

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ $ docker run -it alert_stream python bin/sendAlertStream.py -h
 Start an alert stream to topic “my-stream” with 100 alerts:
 
 ```
-$ docker run -it --network=alertstream_default alert_stream python bin/sendAlertStream.py my-stream 100
+$ docker run -it \
+      --network=alertstream_default \
+      alert_stream python bin/sendAlertStream.py my-stream 100
 ```
 
 To exclude sending postage stamp cutouts, add the optional flag to the python command `--no-stamps`.
@@ -53,13 +55,17 @@ Avro encoding is turned on by default to enforce a schema. To turn this off, add
 To start a consumer for monitoring "my-stream", which will consume a stream and print only End of Partition status messages:
 
 ```
-$ docker run -it --network=alertstream_default alert_stream python bin/monitorStream.py my-stream monitor-group
+$ docker run -it \
+      --network=alertstream_default \
+      alert_stream python bin/monitorStream.py my-stream monitor-group
 ```
 
 To start a consumer for printing all alerts in the stream "my-stream":
 
 ```
-$ docker run -it --network=alertstream_default alert_stream python bin/printStream.py my-stream echo-group
+$ docker run -it \
+      --network=alertstream_default \
+      alert_stream python bin/printStream.py my-stream echo-group
 ```
 
 By default, `printStream.py` will not collect postage stamp cutouts. To enable postage stamp collection, specify a directory to which files should be written with the optional flag `--stampDir <directory name>`. If run using a Docker container, the stamps will be collected within the container.
@@ -96,31 +102,49 @@ docker@node1:~$ docker network create --driver overlay kafkanet
 Start a zookeeper service:
 
 ```
-docker@node1:~$ docker service create --name zookeeper --network kafkanet -p 2181 wurstmeister/zookeeper
+docker@node1:~$ docker service create \
+                    --name zookeeper \
+                    --network kafkanet \
+                    -p 2181 \
+                    wurstmeister/zookeeper
 ```
 
 Start a kafka service:
 
 ```
-docker@node1:~$ docker service create --name  kafka --network kafkanet -p 9092 -e KAFKA_ADVERTISED_HOST_NAME=kafka confluent/kafka
+docker@node1:~$ docker service create \
+                    --name kafka \
+                    --network kafkanet \
+                    -p 9092 \
+                    -e KAFKA_ADVERTISED_HOST_NAME=kafka \
+                    confluent/kafka
 ```
 
-Send some alerts:
+Send 10 alerts to the topic named 'my-stream':
 
 ```
-docker@node1:~$ docker service create  --name producer1 --network kafkanet alert_stream python bin/sendAlertStream.py my-stream 10
+docker@node1:~$ docker service create \
+                    --name producer1 \
+                    --network kafkanet \
+                    alert_stream python bin/sendAlertStream.py my-stream 10
 ```
 
 Listen and print alerts:
 
 ```
-docker@node1:~$ docker service create  --name consumer1 --network kafkanet alert_stream python bin/printStream.py my-stream echo-group
+docker@node1:~$ docker service create \
+                    --name consumer1 \
+                    --network kafkanet \
+                    alert_stream python bin/printStream.py my-stream echo-group
 ```
 
 Monitor alerts:
 
 ```
-docker@node1:~$ docker service create  --name consumer2 --network kafkanet alert_stream python bin/monitorStream.py my-stream monitor-group
+docker@node1:~$ docker service create \
+                    --name consumer2 \
+                    --network kafkanet \
+                    alert_stream python bin/monitorStream.py my-stream monitor-group
 ```
 
 Services are running in the background, but output can be observed by attaching to individual containers or by checking the docker logs on whichever host they are deployed.
@@ -143,5 +167,8 @@ $ docker run -it alert_stream python
 To collect postage stamp cutouts to your local machine, you can mount a local directory and give the Docker container write access with, e.g., the following command:
 
 ```
-$ docker run -it --network=alertstream_default -v $PWD/stamps:/home/alert_stream/stamps:rw alert_stream python bin/printStream.py my-stream echo-group --stampDir stamps
+$ docker run -it \
+      --network=alertstream_default \
+      -v $PWD/stamps:/home/alert_stream/stamps:rw \
+      alert_stream python bin/printStream.py my-stream echo-group --stampDir stamps
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ From the alert_stream directory:
 $ docker-compose up -d
 ```
 
+This will create a network named `alertstream_default` with the default driver over which the other containers will connect.
+
 **Build docker container**
 
 From the alert_stream directory:
@@ -39,7 +41,7 @@ $ docker run -it alert_stream python bin/sendAlertStream.py -h
 Start an alert stream to topic “my-stream” with 100 alerts:
 
 ```
-$ docker run -it --network=host alert_stream python bin/sendAlertStream.py my-stream 100
+$ docker run -it --network=alertstream_default alert_stream python bin/sendAlertStream.py my-stream 100
 ```
 
 To exclude sending postage stamp cutouts, add the optional flag to the python command `--no-stamps`.
@@ -51,13 +53,13 @@ Avro encoding is turned on by default to enforce a schema. To turn this off, add
 To start a consumer for monitoring "my-stream", which will consume a stream and print only End of Partition status messages:
 
 ```
-$ docker run -it --network=host alert_stream python bin/monitorStream.py my-stream monitor-group
+$ docker run -it --network=alertstream_default alert_stream python bin/monitorStream.py my-stream monitor-group
 ```
 
 To start a consumer for printing all alerts in the stream "my-stream":
 
 ```
-$ docker run -it --network=host alert_stream python bin/printStream.py my-stream echo-group
+$ docker run -it --network=alertstream_default alert_stream python bin/printStream.py my-stream echo-group
 ```
 
 By default, `printStream.py` will not collect postage stamp cutouts. To enable postage stamp collection, specify a directory to which files should be written with the optional flag `--stampDir <directory name>`. If run using a Docker container, the stamps will be collected within the container.
@@ -92,5 +94,5 @@ $ docker run -it alert_stream python
 To collect postage stamp cutouts to your local machine, you can mount a local directory and give the Docker container write access with, e.g., the following command:
 
 ```
-$ docker run -it --network=host -v $PWD/stamps:/home/alert_stream/stamps:rw alert_stream python bin/printStream.py my-stream echo-group --stampDir stamps
+$ docker run -it --network=alertstream_default -v $PWD/stamps:/home/alert_stream/stamps:rw alert_stream python bin/printStream.py my-stream echo-group --stampDir stamps
 ```

--- a/bin/monitorStream.py
+++ b/bin/monitorStream.py
@@ -23,7 +23,7 @@ def main():
     args = parser.parse_args()
 
     # Configure consumer connection to Kafka broker
-    conf = {'bootstrap.servers': 'localhost:9092',
+    conf = {'bootstrap.servers': 'kafka:9092',
             'group.id': args.group,
             'default.topic.config': {'auto.offset.reset': 'smallest'}}
 

--- a/bin/printStream.py
+++ b/bin/printStream.py
@@ -57,7 +57,7 @@ def main():
     args = parser.parse_args()
 
     # Configure consumer connection to Kafka broker
-    conf = {'bootstrap.servers': 'localhost:9092',
+    conf = {'bootstrap.servers': 'kafka:9092',
             'group.id': args.group,
             'default.topic.config': {'auto.offset.reset': 'smallest'}}
 

--- a/bin/sendAlertStream.py
+++ b/bin/sendAlertStream.py
@@ -42,7 +42,7 @@ def main():
     args = parser.parse_args()
 
     # Configure producer connection to Kafka broker
-    conf = {'bootstrap.servers': 'localhost:9092'}
+    conf = {'bootstrap.servers': 'kafka:9092'}
 
     # Configure Avro writer schema and data
     schema_files = ["../sample-avro-alert/schema/diasource.avsc",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '2'
+version: '2.1'
 services:
   kafka:
     image: confluent/kafka
     environment:
-      - KAFKA_ADVERTISED_HOST_NAME=localhost
+      - KAFKA_ADVERTISED_HOST_NAME=kafka
     ports:
       - "9092:9092"
     links:

--- a/docker/setup-hosts.sh
+++ b/docker/setup-hosts.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+NODES=3
+
+
+## Create multiple hosts
+for N in $(seq 1 $NODES)
+do
+docker-machine create --driver virtualbox node$N
+done
+
+
+## Set up swarm
+### node1 as manager and others as workers
+SWARM_ADDR=$(docker-machine ip node1)
+
+docker-machine ssh node1 docker swarm init --advertise-addr $SWARM_ADDR
+
+SWARM_TOKEN=$(docker-machine ssh node1 docker swarm join-token -q worker)
+
+for N in $(seq 2 $NODES)
+do
+docker-machine ssh node$N docker swarm join --token $SWARM_TOKEN $SWARM_ADDR:2377
+done
+
+
+## Set up hosts
+for N in $(seq 1 $NODES)
+do
+docker-machine ssh node$N 'git clone https://github.com/lsst-dm/alert_stream.git && cd alert_stream \
+ && git checkout tickets/DM-8537 && docker build -t "alert_stream" .'
+done


### PR DESCRIPTION
The previous version of the system exposed ports on every running container to localhost and used localhost as the Kafka broker access point.  These changes work either on a single host or across multiple hosts, needed for scaling up.