### PR TITLE
DM-9802: Update base docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# Version: 0.0.2
-FROM python:3.5
-MAINTAINER Maria Patterson "maria.t.patterson@gmail.com"
-ENV REFRESHED_AT 2016-12-06
+# Version: 0.0.3
+FROM python:3.6
+LABEL maintainer "maria.t.patterson@gmail.com"
+ENV REFRESHED_AT 2017-03-14
 
 # Install library for confluent-kafka python.
 WORKDIR /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV REFRESHED_AT 2017-03-14
 
 # Install library for confluent-kafka python.
 WORKDIR /home
-RUN git clone https://github.com/edenhill/librdkafka.git && cd librdkafka && git checkout tags/v0.9.2
+RUN git clone https://github.com/edenhill/librdkafka.git && cd librdkafka && git checkout tags/v0.9.4
 WORKDIR /home/librdkafka
 RUN ./configure && make && make install
 ENV LD_LIBRARY_PATH /usr/local/lib

--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ Start a zookeeper service:
 docker@node1:~$ docker service create \
                     --name zookeeper \
                     --network kafkanet \
-                    -p 2181 \
-                    wurstmeister/zookeeper
+                    -p 32181 \
+                    -e ZOOKEEPER_CLIENT_PORT=32181 \
+                    -e ZOOKEEPER_TICK_TIME=2000 \
+                    confluentinc/cp-zookeeper
 ```
 
 Start a kafka service:
@@ -124,8 +126,10 @@ docker@node1:~$ docker service create \
                     --name kafka \
                     --network kafkanet \
                     -p 9092 \
-                    -e KAFKA_ADVERTISED_HOST_NAME=kafka \
-                    confluent/kafka
+                    -e KAFKA_BROKER_ID=1 \
+                    -e KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181 \
+                    -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092 \
+                    confluentinc/cp-kafka
 ```
 
 Start stream of bursts of 10 alerts to the topic named 'my-stream':

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,21 @@
-version: '2.1'
+version: '3.1'
+
 services:
-  kafka:
-    image: confluent/kafka
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
     environment:
-      - KAFKA_ADVERTISED_HOST_NAME=kafka
+      - ZOOKEEPER_CLIENT_PORT=32181
+      - ZOOKEEPER_TICK_TIME=2000
     ports:
-      - "9092:9092"
-    links:
-      - zookeeper
+        - "32181:32181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
     depends_on:
       - zookeeper
-  zookeeper:
-    image: wurstmeister/zookeeper
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
     ports:
-        - "2181:2181"
+      - "9092:9092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:3.2.0
     environment:
       - ZOOKEEPER_CLIENT_PORT=32181
       - ZOOKEEPER_TICK_TIME=2000
@@ -10,7 +10,7 @@ services:
         - "32181:32181"
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:3.2.0
     depends_on:
       - zookeeper
     environment:

--- a/docker/setup-hosts.sh
+++ b/docker/setup-hosts.sh
@@ -28,5 +28,5 @@ done
 for N in $(seq 1 $NODES)
 do
 docker-machine ssh node$N 'git clone https://github.com/lsst-dm/alert_stream.git && cd alert_stream \
- && git checkout tickets/DM-7456 && docker build -t "alert_stream" .'
+ && docker build -t "alert_stream" .'
 done


### PR DESCRIPTION
Swapping out the base docker images used for alert_stream, kafka, and zookeeper.  The updated versions have features/performance we will want either now or at some point later, so upgrading these to the current stable version before doing performance testing.