### PR TITLE
Use master branch for sample-avro-alert repo in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN pip install avro-python3
 RUN pip install Cython
 RUN pip install fastavro
 
-# Get schemas and template data. # TODO update to checkout master when schema is updated
+# Get schemas and template data.
 WORKDIR /home
-RUN git clone https://github.com/lsst-dm/sample-avro-alert.git && cd sample-avro-alert && git checkout tickets/DM-8160
+RUN git clone https://github.com/lsst-dm/sample-avro-alert.git
 
 # Add code.
 RUN mkdir alert_stream


### PR DESCRIPTION
The Dockerfile contains a note concerning schemas and template data:
```bash
# Get schemas and template data. # TODO update to checkout master when schema is updated
WORKDIR /home
RUN git clone https://github.com/lsst-dm/sample-avro-alert.git && cd sample-avro-alert && git checkout tickets/DM-8160
```

Looking at the [PR](https://github.com/lsst-dm/sample-avro-alert/pulls?q=is%3Apr+is%3Aclosed) list, this has been merged into master, hence the proposed fix:
```bash
# Get schemas and template data.
WORKDIR /home
RUN git clone https://github.com/lsst-dm/sample-avro-alert.git
```
