### PR TITLE
New and updated schemas recently added in the sample-avro-alert repo (DM-16280)

### DIFF
--- a/bin/sendAlertStream.py
+++ b/bin/sendAlertStream.py
@@ -59,6 +59,8 @@ def main():
 
     # Configure Avro writer schema and data
     schema_files = ["../sample-avro-alert/schema/diasource.avsc",
+                    "../sample-avro-alert/schema/diaforcedsource.avsc",
+                    "../sample-avro-alert/schema/dianondetectionlimit.avsc",
                     "../sample-avro-alert/schema/diaobject.avsc",
                     "../sample-avro-alert/schema/ssobject.avsc",
                     "../sample-avro-alert/schema/cutout.avsc",


### PR DESCRIPTION
Hi,

## Context 
In the last PR (#20), the Dockerfile was modified to pull the master branch of [sample-avro-alert](https://github.com/lsst-dm/sample-avro-alert) instead of another (merged) branch.

However, in between this previous used branch and the current master of the [sample-avro-alert](https://github.com/lsst-dm/sample-avro-alert) repo, another PR was merged with several modifications (see [PR:DM-16280](https://github.com/lsst-dm/sample-avro-alert/pull/4)). These new changes unfortunately break the functioning of this repo (my bad, I should have seen it earlier...).

## New Schemas

[PR:DM-16280](https://github.com/lsst-dm/sample-avro-alert/pull/4) introduced new schemas. I have modified schemas to comply with it (see https://github.com/lsst-dm/alert_stream/commit/2e32bf13ca8ed72e8fe8a400497fdf0e136a59d6):

```python
# in bin/sendAlertStream.py
schema_files = [
  "../sample-avro-alert/schema/diasource.avsc",
  "../sample-avro-alert/schema/diaforcedsource.avsc", 
  "../sample-avro-alert/schema/dianondetectionlimit.avsc",
  "../sample-avro-alert/schema/diaobject.avsc",
  "../sample-avro-alert/schema/ssobject.avsc",
  "../sample-avro-alert/schema/cutout.avsc",
  "../sample-avro-alert/schema/alert.avsc"]
```

## Modifications of values in schemas
 
Unfortunately, not only new schemas were introduced but values in existing ones were also modified.
Hence the data provided in this repo is no more valid. Example, if I want to produce an alert stream:
```bash
docker run -it --rm \     
  --network=alert_stream_default \
  -v $PWD/data:/home/alert_stream/data:ro alert_stream \
  python bin/sendAlertStream.py kafka:9092 my-stream

visit: 1574. 	time: 1548757977.0034723
Task exception was never retrieved
future: <Task finished coro=<schedule_delays() done, defined at bin/sendAlertStream.py:29> exception=ValueError('no value and no default for programId',)>
Traceback (most recent call last):
  File "bin/sendAlertStream.py", line 46, in schedule_delays
    yield from asyncio.ensure_future(delay(wait_time, function, arg))
  File "bin/sendAlertStream.py", line 26, in delay
    return function(*args)
  File "bin/sendAlertStream.py", line 89, in send_visit
    streamProducer.send(record, encode=True)
  File "/home/alert_stream/python/lsst/alert/stream/alertProducer.py", line 38, in send
    avro_bytes = avroUtils.writeAvroData(data, self.alert_schema)
  File "/home/alert_stream/python/lsst/alert/stream/avroUtils.py", line 59, in writeAvroData
    fastavro.schemaless_writer(bytes_io, json_schema, json_data)
  File "fastavro/_write.pyx", line 731, in fastavro._write.schemaless_writer
  File "fastavro/_write.pyx", line 537, in fastavro._write.write_data
  File "fastavro/_write.pyx", line 474, in fastavro._write.write_record
  File "fastavro/_write.pyx", line 537, in fastavro._write.write_data
  File "fastavro/_write.pyx", line 473, in fastavro._write.write_record
ValueError: no value and no default for programId
```

The `programId` key is for example such a new value introduced. 

## What else should be done?

My feeling is that data in this repo needs to be reprocessed with the (new+updated) schemas from the [sample-avro-alert](https://github.com/lsst-dm/sample-avro-alert) repo. What do you think? If so, how can I re-generate this data to test this?